### PR TITLE
attributes: check if a skipped parameter exists (#600) 

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -210,6 +210,19 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
             FnArg::Typed(PatType { pat, .. }) => param_names(*pat),
             FnArg::Receiver(_) => Box::new(iter::once(Ident::new("self", param.span()))),
         })
+        .collect();
+
+    for skip in &skips {
+        if !param_names.contains(skip) {
+            return quote_spanned!(skip.span()=>
+                compile_error!("attempting to skip non-existent parameter")
+            )
+            .into();
+        }
+    }
+
+    let param_names: Vec<Ident> = param_names
+        .into_iter()
         .filter(|ident| !skips.contains(ident))
         .collect();
 


### PR DESCRIPTION
This PR adds a check to the `#[instrument]` macro to emit a compiler
error if the user tries to skip non-existing parameters.

Fixes: #562

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
