### PR TITLE
attributes: instrument Err (#637)

### DIFF
--- a/tracing-attributes/src/lib.rs
+++ b/tracing-attributes/src/lib.rs
@@ -146,6 +146,17 @@ use syn::{
 /// }
 /// ```
 ///
+/// If the function returns a `Result<T, E>` and `E` implements `std::fmt::Display`, you can add
+/// `err` to emit error events when the function returns `Err`:
+///
+/// ```
+/// # use tracing_attributes::instrument;
+/// #[instrument(err)]
+/// fn my_function(arg: usize) -> Result<(), std::io::Error> {
+///     Ok(())
+/// }
+/// ```
+///
 /// If `tracing_futures` is specified as a dependency in `Cargo.toml`,
 /// `async fn`s may also be instrumented:
 ///
@@ -262,14 +273,40 @@ pub fn instrument(args: TokenStream, item: TokenStream) -> TokenStream {
     // If the function is an `async fn`, this will wrap it in an async block,
     // which is `instrument`ed using `tracing-futures`. Otherwise, this will
     // enter the span and then perform the rest of the body.
+    // If `err` is in args, instrument any resulting `Err`s.
     let body = if asyncness.is_some() {
-        quote_spanned! {block.span()=>
-            tracing_futures::Instrument::instrument(
-                async move { #block },
-                __tracing_attr_span
-            )
-                .await
+        if instrument_err(&args) {
+            quote_spanned! {block.span()=>
+                tracing_futures::Instrument::instrument(async move {
+                    match async move { #block }.await {
+                        Ok(x) => Ok(x),
+                        Err(e) => {
+                            tracing::error!(error = %e);
+                            Err(e)
+                        }
+                    }
+                }, __tracing_attr_span).await
+            }
+        } else {
+            quote_spanned! {block.span()=>
+                tracing_futures::Instrument::instrument(
+                    async move { #block },
+                    __tracing_attr_span
+                )
+                    .await
+            }
         }
+    } else if instrument_err(&args) {
+        quote_spanned!(block.span()=>
+            let __tracing_attr_guard = __tracing_attr_span.enter();
+            match { #block } {
+                Ok(x) => Ok(x),
+                Err(e) => {
+                    tracing::error!(error = %e);
+                    Err(e)
+                }
+            }
+        )
     } else {
         quote_spanned!(block.span()=>
             let __tracing_attr_guard = __tracing_attr_span.enter();
@@ -534,4 +571,11 @@ fn name(args: &[NestedMeta], default_name: String) -> impl ToTokens {
         }
         None => quote!(#default_name),
     }
+}
+
+fn instrument_err(args: &[NestedMeta]) -> bool {
+    args.iter().any(|arg| match arg {
+        NestedMeta::Meta(Meta::Path(path)) => path.is_ident("err"),
+        _ => false,
+    })
 }

--- a/tracing-attributes/tests/err.rs
+++ b/tracing-attributes/tests/err.rs
@@ -1,0 +1,64 @@
+#[path = "../../tracing-futures/tests/support.rs"]
+// we don't use some of the test support functions, but `tracing-futures` does.
+#[allow(dead_code)]
+mod support;
+use support::*;
+
+use tracing::subscriber::with_default;
+use tracing::Level;
+use tracing_attributes::instrument;
+
+use std::convert::TryFrom;
+use std::num::TryFromIntError;
+
+#[instrument(err)]
+fn err() -> Result<u8, TryFromIntError> {
+    u8::try_from(1234)
+}
+
+#[test]
+fn test() {
+    let span = span::mock().named("err");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(event::mock().at_level(Level::ERROR))
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || err().ok());
+    handle.assert_finished();
+}
+
+#[instrument(err)]
+async fn err_async(polls: usize) -> Result<u8, TryFromIntError> {
+    let future = PollN::new_ok(polls);
+    tracing::trace!(awaiting = true);
+    future.await.ok();
+    u8::try_from(1234)
+}
+
+#[test]
+fn test_async() {
+    let span = span::mock().named("err_async");
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span.clone())
+        .enter(span.clone())
+        .event(
+            event::mock()
+                .with_fields(field::mock("awaiting").with_value(&true))
+                .at_level(Level::TRACE),
+        )
+        .exit(span.clone())
+        .enter(span.clone())
+        .event(event::mock().at_level(Level::ERROR))
+        .exit(span.clone())
+        .drop_span(span)
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || {
+        block_on_future(async { err_async(2).await }).ok();
+    });
+    handle.assert_finished();
+}


### PR DESCRIPTION
* attributes: instrument Err

This adds `#[instrument(err)]`, which will emit an error-level trace
event if the caller returns an `Err`.

Fixes #545.

* attributes: use field instead of format args

* attributes: note `err` needs Display impl

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
